### PR TITLE
Output the ID of the newly created release for subsequent automation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,7 +75,14 @@ workflows:
                 exit 1
               fi
 
+              if [ -z $APPCENTER_DEPLOY_RELEASE_ID ];
+              then
+                echo "ERROR: APPCENTER_DEPLOY_RELEASE_ID variable empty"
+                exit 1
+              fi
+
               envman add --key "APPCENTER_DEPLOY_INSTALL_URL" --value ""
               envman add --key "APPCENTER_DEPLOY_DOWNLOAD_URL" --value ""
               envman add --key "APPCENTER_PUBLIC_INSTALL_PAGE_URL" --value ""
               envman add --key "APPCENTER_DEPLOY_STATUS" --value ""
+              envman add --key "APPCENTER_DEPLOY_RELEASE_ID" --value ""

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"strconv"
 
 	"github.com/bitrise-io/appcenter"
 	"github.com/bitrise-io/go-steputils/stepconf"
@@ -156,6 +157,7 @@ func main() {
 		statusEnvKey:                    "success",
 		"APPCENTER_DEPLOY_INSTALL_URL":  release.InstallURL,
 		"APPCENTER_DEPLOY_DOWNLOAD_URL": release.DownloadURL,
+		"APPCENTER_DEPLOY_RELEASE_ID": strconv.Itoa(release.ID),
 	}
 
 	if len(publicGroup) > 0 {

--- a/step.yml
+++ b/step.yml
@@ -130,3 +130,8 @@ outputs:
       title: Public install page URL
       summary: Public install page URL of the latest version
       description: Public install page URL of the latest version
+  - APPCENTER_DEPLOY_RELEASE_ID:
+    opts:
+      title: Release ID
+      summary: ID of the new release for later retrieval via App Center APIs.
+      description: ID of the new release for later retrieval via App Center APIs.


### PR DESCRIPTION
Outputting the ID of the newly created App Center release, so it can be used in subsequent steps to retrieve the full release data, and manipulate the release further via App Center APIs

Currently only HTTP links are returned for manual interaction with the new release, thats all fine for logging and notification etc, but is not robust for further automation of the release (ie subsequent build steps that automate promotion and distribution of the new release through multiple App Center distribution groups via API).

By adding the release ID to the output it enables many use cases for subsequent automation

Tested by successful integration into our Bitrise CI pipeline